### PR TITLE
Updated Readme usage with styleguidist config

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ let metadata = files.map(path => {
 })
 ```
 
-##### Usage with styleguidist
+##### Usage with react-styleguidist
 
-Enable `handlers` config in `styleguidist.config.js`
+Enable `handlers` property in styleguidist config(`styleguidist.config.js`)
 ```js
 module.export = {
   handlers: componentPath =>

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export default iconNames
 
 &nbsp;
 
-#### usage
+#### Usage
 
 ```js
 const docgen = require('react-docgen')
@@ -106,6 +106,19 @@ let metadata = files.map(path => {
 
   return data
 })
+```
+
+##### Usage with styleguidist
+
+Enable `handlers` config in `styleguidist.config.js`
+```js
+module.export = {
+  handlers: componentPath =>
+    require('react-docgen').defaultHandlers.concat(
+        require('react-docgen-external-proptypes-handler')(componentPath),
+        require('react-docgen-displayname-handler').createDisplayNameHandler(componentPath)
+      )
+}
 ```
 
 &nbsp;


### PR DESCRIPTION
@siddharthkp , I have updated Readme usage with styleguidist config as most of them are using it with react-styleguidist. And also usage steps are not clear for most of them, because most of the developers are thinking that the given sample usage config is for react-styleguidist. That config works well with react-docgen alone, but not with other tools like react-styeguidist. 