### PR TITLE
Fix masking of Babel config errors in babelParser require try/catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ try {
   const buildParser = require('react-docgen/dist/babelParser').default
   babylon = buildParser()
 } catch (e) {
+  // Try babylon if requiring babelParser fails, but don't mask Babel config errors
+  if (e.message.indexOf('Cannot find module') === -1) {
+    throw e
+  }
   babylon = require('react-docgen/dist/babylon').default
 }
 


### PR DESCRIPTION
When `require('react-docgen/dist/babelParser')` succeeds, but a Babel config error causes `babylon = buildParser()` to throw an error this was caught in the try/catch block which then does `require('react-docgen/dist/babylon')` which fails in turn because `babylon` does not exist. The resulting error message is that of the latter error instead of the actual Babel config error message. This patch resolves the problem by rethrowing the error on anything other than a failed require.